### PR TITLE
Fix two typos in the 'Supported ciphers' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,8 +310,8 @@ Definition of abbreviations:
 * SHA256 = Secure Hash Algorithm 2 (256 bit hash)
 * SHA512 = Secure Hash Algorithm 2 (512 bit hash)
 
-Each of these algorithme can be used with default configuration or configured.
-Configuration parameters are given bellow.  
+Each of these algorithms can be used with default configuration or configured.
+Configuration parameters are given below.
 ##### AES 128 Bit CBC - No HMAC (wxSQLite3)
 
 This cipher was added to **wxSQLite3** in 2007 as the first supported encryption scheme. It is a 128 bit AES encryption in CBC mode.


### PR DESCRIPTION
Found a few typos while reading the README