### PR TITLE
froze dockross images version

### DIFF
--- a/docker/dockcross-android-arm
+++ b/docker/dockcross-android-arm
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/android-arm:latest
+DEFAULT_DOCKCROSS_IMAGE=dockcross/android-arm:20220409-7e72803
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-android-arm64
+++ b/docker/dockcross-android-arm64
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/android-arm64:latest
+DEFAULT_DOCKCROSS_IMAGE=dockcross/android-arm64:20220409-7e72803
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-android-x86
+++ b/docker/dockcross-android-x86
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/android-x86:latest
+DEFAULT_DOCKCROSS_IMAGE=dockcross/android-x86:20220409-7e72803
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-android-x86_64
+++ b/docker/dockcross-android-x86_64
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/android-x86_64:latest
+DEFAULT_DOCKCROSS_IMAGE=dockcross/android-x86_64:20220409-7e72803
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-arm64
+++ b/docker/dockcross-arm64
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-arm64:latest
+DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-arm64:20220409-7e72803
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-armv5
+++ b/docker/dockcross-armv5
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-armv5:latest
+DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-armv5:20220409-7e72803
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-armv6
+++ b/docker/dockcross-armv6
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-armv6-lts:latest
+DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-armv6-lts:20220409-7e72803
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-armv7
+++ b/docker/dockcross-armv7
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-armv7:latest
+DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-armv7:20220409-7e72803
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-armv7a
+++ b/docker/dockcross-armv7a
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-armv7a:latest
+DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-armv7a:20220409-7e72803
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-ppc64
+++ b/docker/dockcross-ppc64
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-ppc64le:latest
+DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-ppc64le:20220409-7e72803
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-windows-arm64
+++ b/docker/dockcross-windows-arm64
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/windows-arm64:latest
+DEFAULT_DOCKCROSS_IMAGE=dockcross/windows-arm64:20220409-7e72803
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-windows-armv7
+++ b/docker/dockcross-windows-armv7
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/windows-armv7:latest
+DEFAULT_DOCKCROSS_IMAGE=dockcross/windows-armv7:20220409-7e72803
 
 #------------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
This is needed to avoid compilation issues with "latest" version of some cross-compilation tool chain