### PR TITLE
Updated versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,11 @@ $(SQLITE_OUT)/sqlite3.o : $(SQLITE_UNPACKED)
 	@mkdir -p $(@D)
 	cp $(TARGET)/$(SQLITE_AMAL_PREFIX)/* $(SQLITE_OUT)/
 
+    # Temporary workaround for quadmath on Windows ARM64
+	perl -p -e "s/#if defined\(__GNUC__\) && defined\(_WIN64\)/#if defined(__GNUC__) && defined(_WIN64) && defined(__x86_64__)/;" \
+	    $(SQLITE_OUT)/sqlite3mc_amalgamation.c > $(SQLITE_OUT)/sqlite3mc_amalgamation.c.tmp
+	cat $(SQLITE_OUT)/sqlite3mc_amalgamation.c.tmp > $(SQLITE_OUT)/sqlite3mc_amalgamation.c
+
 
 #	perl -p -e "s/sqlite3_api;/sqlite3_api = 0;/g" \
 	    $(SQLITE_SOURCE)/sqlite3ext.h > $(SQLITE_OUT)/sqlite3ext.h

--- a/Makefile.common
+++ b/Makefile.common
@@ -233,7 +233,7 @@ ifeq ($(wildcard MAC_SDK),)
 	MAC_SDK := /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk
 endif
 Mac-x86_64_CCFLAGS    := -I$(MAC_SDK)/System/Library/Frameworks/JavaVM.framework/Headers -Ilib/inc_mac -Os -fPIC -mmacosx-version-min=10.6 -fvisibility=hidden -msse4.2 -maes -Wno-implicit-function-declaration
-Mac-x86_64_LINKFLAGS := -dynamiclib 
+Mac-x86_64_LINKFLAGS := -dynamiclib -framework Security
 Mac-x86_64_LIBNAME   := libsqlitejdbc.jnilib
 Mac-x86_64_SQLITE_FLAGS  := 
 
@@ -243,7 +243,7 @@ Mac-aarch64_CC        := $(CROSS_PREFIX)clang
 Mac-aarch64_STRIP     := $(CROSS_PREFIX)strip -x
 MAC_SDK := /usr/osxcross/SDK/MacOSX11.3.sdk
 Mac-aarch64_CCFLAGS    := -I$(MAC_SDK)/System/Library/Frameworks/JavaVM.framework/Headers -Ilib/inc_mac -Os -fPIC -mmacosx-version-min=10.9 -fvisibility=hidden -Wno-implicit-function-declaration
-Mac-aarch64_LINKFLAGS  := -dynamiclib
+Mac-aarch64_LINKFLAGS  := -dynamiclib -framework Security
 Mac-aarch64_LIBNAME    := libsqlitejdbc.jnilib
 Mac-aarch64_SQLITE_FLAGS := 
 
@@ -257,7 +257,7 @@ Windows-x86_SQLITE_FLAGS :=
 Windows-x86_64_CC           := $(CROSS_PREFIX)gcc
 Windows-x86_64_STRIP        := $(CROSS_PREFIX)strip
 Windows-x86_64_CCFLAGS      := -D_JNI_IMPLEMENTATION_ -Ilib/inc_win -Os -msse4.2 -maes
-Windows-x86_64_LINKFLAGS    := -Wl,--kill-at -shared -static-libgcc
+Windows-x86_64_LINKFLAGS    := -Wl,--kill-at -shared -static-libgcc -lquadmath
 Windows-x86_64_LIBNAME      := sqlitejdbc.dll
 Windows-x86_64_SQLITE_FLAGS :=
 

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,3 @@
-version=3.41.2
-artifactVersion=3.41.2.1
-sqliteMCVersion=1.6.2
+version=3.44.0
+artifactVersion=3.44.0.1
+sqliteMCVersion=1.7.4

--- a/docker/dockcross-android-arm
+++ b/docker/dockcross-android-arm
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/android-arm:20220409-7e72803
+DEFAULT_DOCKCROSS_IMAGE=dockcross/android-arm:latest
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-android-arm64
+++ b/docker/dockcross-android-arm64
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/android-arm64:20220409-7e72803
+DEFAULT_DOCKCROSS_IMAGE=dockcross/android-arm64:latest
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-android-x86
+++ b/docker/dockcross-android-x86
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/android-x86:20220409-7e72803
+DEFAULT_DOCKCROSS_IMAGE=dockcross/android-x86:latest
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-android-x86_64
+++ b/docker/dockcross-android-x86_64
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/android-x86_64:20220409-7e72803
+DEFAULT_DOCKCROSS_IMAGE=dockcross/android-x86_64:latest
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-armv5
+++ b/docker/dockcross-armv5
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-armv5:20220409-7e72803
+DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-armv5:latest
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-armv6-lts
+++ b/docker/dockcross-armv6-lts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-armv6-lts:20220409-7e72803
+DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-armv6-lts:latest
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-ppc64
+++ b/docker/dockcross-ppc64
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-ppc64le:20220409-7e72803
+DEFAULT_DOCKCROSS_IMAGE=dockcross/linux-ppc64le:latest
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-windows-arm64
+++ b/docker/dockcross-windows-arm64
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/windows-arm64:20220409-7e72803
+DEFAULT_DOCKCROSS_IMAGE=dockcross/windows-arm64:latest
 
 #------------------------------------------------------------------------------
 # Helpers

--- a/docker/dockcross-windows-armv7
+++ b/docker/dockcross-windows-armv7
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_DOCKCROSS_IMAGE=dockcross/windows-armv7:20220409-7e72803
+DEFAULT_DOCKCROSS_IMAGE=dockcross/windows-armv7:latest
 
 #------------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
This PR enables compiling for me on my VM. I worked on the master branch.

All versions were updated.
The workaround about Win ARM64 can be removed when Multiple Ciphers delivers a new version (with quadmath disabled by default):
https://github.com/utelle/SQLite3MultipleCiphers/issues/126

